### PR TITLE
+ номер аудитории при редактировании мероприятия

### DIFF
--- a/src/pages/main/EventData/UpdateDialogContext.tsx
+++ b/src/pages/main/EventData/UpdateDialogContext.tsx
@@ -429,7 +429,7 @@ const UpdateDialogContent = ({ eventId, onSubmit, eventInfo }: Props) => {
                   className={errors.place?styles.input_error:''}>
             {placesLoaded ? (
               placeList.map((p) => {
-                return <option key={p.id} value={p.id}>{p.address}</option>;
+                return <option key={p.id} value={p.id}>{p.address}{p.room ? ", ауд. " + p.room : ""}</option>;
               })
             ) : (
               <option value=""></option>


### PR DESCRIPTION
В адресе нет аудитории, из-за чего в списке площадок был бы только условный Кронверкский 49

<img width="360" alt="Снимок экрана 2024-04-18 в 21 02 12" src="https://github.com/itmo-events-app/frontend/assets/25708359/244ec79e-d206-490d-8278-41ffa94338b3">
